### PR TITLE
fix(agent): remove MCP server disable flags that crash Codex exec

### DIFF
--- a/Sources/TurboDraftAgent/CodexAppServerPromptEngineerAdapter.swift
+++ b/Sources/TurboDraftAgent/CodexAppServerPromptEngineerAdapter.swift
@@ -269,10 +269,6 @@ public final class CodexAppServerPromptEngineerAdapter: AgentAdapting, @unchecke
         "stdio://",
         "-c",
         "web_search=\(webSearch)",
-        "-c",
-        "mcp_servers.context7.enabled=false",
-        "-c",
-        "mcp_servers.playwright.enabled=false",
       ]
 
       // Allow passing additional `-c/--config` overrides to app-server via agent.args.

--- a/Sources/TurboDraftAgent/CodexPromptEngineerAdapter.swift
+++ b/Sources/TurboDraftAgent/CodexPromptEngineerAdapter.swift
@@ -173,8 +173,6 @@ public final class CodexPromptEngineerAdapter: AgentAdapting, @unchecked Sendabl
     let reqEff = reasoningEffortOverride ?? reasoningEffort
     args.append(contentsOf: ["-c", "model_reasoning_effort=\(effectiveReasoningEffort(model: usedModel, requested: reqEff))"])
     args.append(contentsOf: ["-c", "model_reasoning_summary=\(reasoningSummary)"])
-    args.append(contentsOf: ["-c", "mcp_servers.context7.enabled=false"])
-    args.append(contentsOf: ["-c", "mcp_servers.playwright.enabled=false"])
 
     args.append(contentsOf: extraArgs)
     args.append("-")


### PR DESCRIPTION
## Root Cause

When TurboDraft runs the Prompt Engineer, it passes:

```
-c mcp_servers.context7.enabled=false
-c mcp_servers.playwright.enabled=false
```

For users who don't have `context7` or `playwright` configured in their `~/.codex/config.toml`, these `-c` flags create a malformed MCP server record (no `transport` field). Codex CLI fails immediately on config load:

```
Error loading config.toml: invalid transport
in `mcp_servers.context7`
```

This exits with code 1 before any model request, making the Prompt Engineer completely non-functional for those users — including the default `gpt-5.3-codex-spark` model.

## Fix

Remove the two MCP server `-c` overrides from both adapters (`CodexPromptEngineerAdapter` and `CodexAppServerPromptEngineerAdapter`). These flags were a defensive measure to prevent MCP server side-effects during prompt-engineer runs, but they harm more users than the interference they were meant to prevent.

## Test Plan

- [x] Confirmed crash repros without fix: `Error loading config.toml: invalid transport in mcp_servers.context7`, exit 1
- [x] Confirmed fix resolves crash: Codex Spark runs successfully to completion
- [x] `scripts/install` passes (release build + LaunchAgent restart)
- [ ] Manually verify Prompt Engineer button works end-to-end in TurboDraft

🤖 Generated with [Claude Code](https://claude.com/claude-code)