### PR TITLE
feat(agent): image upload support for prompt engineer

### DIFF
--- a/Sources/TurboDraftAgent/AgentAdapter.swift
+++ b/Sources/TurboDraftAgent/AgentAdapter.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 public protocol AgentAdapting: Sendable {
-  func draft(prompt: String, instruction: String) async throws -> String
+  func draft(prompt: String, instruction: String, images: [URL]) async throws -> String
 }
 
+extension AgentAdapting {
+  /// Convenience overload for call sites that don't attach images.
+  public func draft(prompt: String, instruction: String) async throws -> String {
+    try await draft(prompt: prompt, instruction: instruction, images: [])
+  }
+}

--- a/Sources/TurboDraftAgent/CodexCLIAgentAdapter.swift
+++ b/Sources/TurboDraftAgent/CodexCLIAgentAdapter.swift
@@ -33,7 +33,7 @@ public final class CodexCLIAgentAdapter: AgentAdapting, @unchecked Sendable {
     self.maxOutputBytes = maxOutputBytes
   }
 
-  public func draft(prompt: String, instruction: String) async throws -> String {
+  public func draft(prompt: String, instruction: String, images: [URL] = []) async throws -> String {
     let input = """
 PROMPT:
 \(prompt)


### PR DESCRIPTION
Closes #3.

## What this does

Lets users attach images to a Prompt Engineer run by pasting them from the clipboard (Cmd+V).

**UX**
- Paste an image → `[image 1]` placeholder inserted at cursor; image queued for the next agent run
- Normal text paste still works unchanged
- Temp PNG files are cleaned up after each agent run

**Exec backend** (`codex exec`)
Each queued image is forwarded via `-i <path>` — the flag `codex exec` already supports for vision models.

**App-server backend** (`codex app-server`)
Each image is base64-encoded and appended as an `image_url` item in the `turn/start` input array alongside the text.

**Protocol change**
`AgentAdapting` gains `draft(prompt:instruction:images:)`. A default extension provides a zero-image overload so all existing call sites (including tests) compile without changes.

## Files changed

| File | Change |
|------|--------|
| `AgentAdapter.swift` | Add `images` param to protocol + default extension |
| `CodexCLIAgentAdapter.swift` | Accept `images` (ignored, basic adapter) |
| `CodexPromptEngineerAdapter.swift` | Thread images → `-i` args in exec call |
| `CodexAppServerPromptEngineerAdapter.swift` | Thread images → base64 `image_url` items in turn input |
| `EditorViewController.swift` | Paste intercept, temp-file save, images wired to agent |

## Test plan

- [x] `swift build` clean
- [x] `scripts/install` passes, LaunchAgent restarted
- [ ] Paste a screenshot → `[image 1]` appears in editor, Improve Prompt sends it to model
- [ ] Normal text paste still works
- [ ] Multiple images paste in sequence each get their own placeholder and index

🤖 Generated with [Claude Code](https://claude.com/claude-code)