### PR TITLE
perf: reduce RAM growth in session history

### DIFF
--- a/Sources/TurboDraftApp/EditorStyler.swift
+++ b/Sources/TurboDraftApp/EditorStyler.swift
@@ -16,7 +16,8 @@ final class MarkdownStyler {
 
   private var cache: [CacheKey: [Highlight]] = [:]
   private var cacheOrder: [CacheKey] = []
-  private let cacheLimit = 512
+  // Keep highlight cache small to avoid long-lived attributed range buildup.
+  private let cacheLimit = 128
 
   private let baseFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
   private let strongFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .semibold)
@@ -143,7 +144,7 @@ final class MarkdownStyler {
 
     cache[key] = out
     cacheOrder.append(key)
-    // O(n) FIFO eviction is fine here — cacheLimit is small (512) and this runs
+    // O(n) FIFO eviction is fine here — cacheLimit is small (128) and this runs
     // at most once per highlight pass, removing only a handful of entries.
     if cacheOrder.count > cacheLimit {
       let removeCount = cacheOrder.count - cacheLimit

--- a/Sources/TurboDraftCore/HistoryStore.swift
+++ b/Sources/TurboDraftCore/HistoryStore.swift
@@ -16,17 +16,28 @@ public struct HistorySnapshot: Sendable, Equatable {
 
 public struct HistoryStore: Sendable {
   private var maxCount: Int
+  private var maxBytes: Int
   private var items: [HistorySnapshot] = []
+  private var itemSizes: [Int] = []
+  private var totalBytes: Int = 0
 
-  public init(maxCount: Int = 32) {
+  public init(maxCount: Int = 32, maxBytes: Int = 2_000_000) {
     self.maxCount = maxCount
+    self.maxBytes = maxBytes
   }
 
   public mutating func append(_ snapshot: HistorySnapshot) {
-    items.append(snapshot)
-    if items.count > maxCount {
-      items.removeFirst(items.count - maxCount)
+    // Consecutive duplicate snapshots are pure memory churn and provide no
+    // additional restore value.
+    if let last = items.last, last.content == snapshot.content {
+      return
     }
+
+    let size = snapshot.content.utf8.count
+    items.append(snapshot)
+    itemSizes.append(size)
+    totalBytes += size
+    trimToBudget()
   }
 
   public func all() -> [HistorySnapshot] { items }
@@ -34,5 +45,17 @@ public struct HistoryStore: Sendable {
   public func find(id: String) -> HistorySnapshot? {
     items.last { $0.id == id }
   }
-}
 
+  private mutating func trimToBudget() {
+    while items.count > maxCount, !items.isEmpty {
+      totalBytes -= itemSizes.removeFirst()
+      items.removeFirst()
+    }
+
+    // Keep at least one snapshot, even when a single entry exceeds budget.
+    while totalBytes > maxBytes, items.count > 1 {
+      totalBytes -= itemSizes.removeFirst()
+      items.removeFirst()
+    }
+  }
+}

--- a/Tests/TurboDraftCoreTests/HistoryStoreTests.swift
+++ b/Tests/TurboDraftCoreTests/HistoryStoreTests.swift
@@ -1,0 +1,36 @@
+import TurboDraftCore
+import XCTest
+
+final class HistoryStoreTests: XCTestCase {
+  func testConsecutiveDuplicateContentIsIgnored() {
+    var store = HistoryStore(maxCount: 8, maxBytes: 10_000)
+    store.append(HistorySnapshot(reason: "first", content: "same"))
+    store.append(HistorySnapshot(reason: "second", content: "same"))
+
+    let items = store.all()
+    XCTAssertEqual(items.count, 1)
+    XCTAssertEqual(items.first?.reason, "first")
+  }
+
+  func testPrunesByCountLimit() {
+    var store = HistoryStore(maxCount: 2, maxBytes: 10_000)
+    store.append(HistorySnapshot(reason: "one", content: "1"))
+    store.append(HistorySnapshot(reason: "two", content: "2"))
+    store.append(HistorySnapshot(reason: "three", content: "3"))
+
+    let reasons = store.all().map(\.reason)
+    XCTAssertEqual(reasons, ["two", "three"])
+  }
+
+  func testPrunesByByteBudgetButKeepsNewestSnapshot() {
+    var store = HistoryStore(maxCount: 10, maxBytes: 10)
+    store.append(HistorySnapshot(reason: "a", content: "12345"))
+    store.append(HistorySnapshot(reason: "b", content: "67890"))
+    store.append(HistorySnapshot(reason: "c", content: "abcdefghij"))
+
+    let items = store.all()
+    XCTAssertEqual(items.count, 1)
+    XCTAssertEqual(items.first?.reason, "c")
+    XCTAssertEqual(items.first?.content, "abcdefghij")
+  }
+}


### PR DESCRIPTION
## Summary
- add byte-budgeted pruning to in-memory `HistoryStore`
- dedupe consecutive identical history snapshots
- keep at least one snapshot when over budget
- reduce `EditorSession` history retention and recovery load size
- reduce markdown highlight cache cap (`512 -> 128`)
- add `HistoryStore` tests for dedupe, count pruning, and byte-budget pruning

## Why
TurboDraft kept full-content snapshots in memory with only a count cap, which could grow resident memory during long sessions. This change bounds snapshot memory by bytes and trims older entries first.

## Key changes
- `Sources/TurboDraftCore/HistoryStore.swift`
  - new `maxBytes` budget
  - size tracking and byte-based pruning
  - consecutive-content dedupe
- `Sources/TurboDraftCore/EditorSession.swift`
  - `historyMaxCount = 32`
  - `historyMaxBytes = 4_000_000`
  - `recoveryLoadCount = 16`
- `Sources/TurboDraftApp/EditorStyler.swift`
  - shrink highlight cache cap to 128
- `Tests/TurboDraftCoreTests/HistoryStoreTests.swift`
  - validate new memory-bounded behavior

## Validation
- `scripts/install`
- `.build/release/turbodraft bench run --path "$(pwd)/bench/fixtures/dictation_flush_mode.md" --warm 8 --cold 2 --warmup-discard 2 --out /tmp/turbodraft-bench-ram-opt.json`
- `.build/release/turbodraft bench check --baseline bench/editor/baseline.json --results /tmp/turbodraft-bench-ram-opt.json`
- `.build/release/turbodraft bench check --baseline bench/baseline.json --results /tmp/turbodraft-bench-ram-opt.json`
- `python3 scripts/bench_ab_compare.py --a /tmp/turbodraft-bench-current.json --b /tmp/turbodraft-bench-ram-opt.json --threshold-pct 5 --out /tmp/turbodraft-bench-ab-ram-opt.json`

## Notes
- `swift test` failed in this environment due missing `XCTest` module (`no such module 'XCTest'`).

Closes #10
